### PR TITLE
Don't save deleted profiles

### DIFF
--- a/classes/Data.ts
+++ b/classes/Data.ts
@@ -370,14 +370,8 @@ export default class Data {
 			for (const profile of saved.profiles) {
 				// If the profile is somehow already added to newData, skip it
 				if (newData.profiles.some(p => p.profile_id === profile.profile_id)) continue;
-
 				// Check if the profile exists on the new data (it should unless deleted)
 				const freshProfile = fresh.profiles.find(p => p.profile_id === profile.profile_id);
-				if (!freshProfile) {
-					// If it doesn't exist, add it with no api
-					newData.profiles.push({ ...profile, api: false });
-					continue;
-				}
 
 				// Get the member data from the fresh profile
 				const freshMember = freshProfile.members[Object.keys(freshProfile.members)[0]];


### PR DESCRIPTION
Profiles that have been deleted on the API should be removed from the bot database as well. This solves the issue of a new profile with the same cute name being impossible to view unless it passes the old one's weight.